### PR TITLE
Launch readiness: claim loop + GA4 analytics + SEO foundations

### DIFF
--- a/backend/database/schema/MasterClaim.js
+++ b/backend/database/schema/MasterClaim.js
@@ -4,6 +4,10 @@ const ObjectId = mongoose.Schema.Types.ObjectId;
 
 const STATUS = ['pending', 'approved', 'rejected', 'withdrawn'];
 const EVIDENCE_TYPES = ['phone_match', 'social_handle', 'admin_attestation', 'other'];
+// Where the claim originated — the Day-4 growth gate splits founder-driven from
+// organic claims. Encoded into the deep link (?startapp=claim-<id>-dm|-org) and
+// parsed client-side; 'unknown' when the suffix is absent (e.g. legacy links).
+const SOURCES = ['founder_dm', 'organic', 'unknown'];
 
 const claimSchema = new mongoose.Schema(
   {
@@ -18,6 +22,7 @@ const claimSchema = new mongoose.Schema(
       },
     ],
     status:      { type: String, enum: STATUS, default: 'pending' },
+    source:      { type: String, enum: SOURCES, default: 'unknown' },
     autoApproved: { type: Boolean, default: false },
     reviewedBy:  { type: ObjectId, ref: 'User' },
     reviewedAt:  Date,
@@ -42,4 +47,5 @@ claimSchema.index(
 const MasterClaim = mongoose.model('MasterClaim', claimSchema);
 MasterClaim.STATUS = STATUS;
 MasterClaim.EVIDENCE_TYPES = EVIDENCE_TYPES;
+MasterClaim.SOURCES = SOURCES;
 module.exports = MasterClaim;

--- a/backend/routes/claims.js
+++ b/backend/routes/claims.js
@@ -3,9 +3,17 @@ const Master = require('../database/schema/Master');
 const MasterClaim = require('../database/schema/MasterClaim');
 const MasterAudit = require('../database/schema/MasterAudit');
 const { requestVerification } = require('../helpers/verification');
+const { masterWebUrl } = require('../helpers/masterUrl');
 const { bot } = require('../bot');
 
 const TELEGRAM_ADMIN_CHAT_ID = process.env.TELEGRAM_ADMIN_CHAT_ID;
+const PUBLIC_WEB_URL = process.env.PUBLIC_WEB_URL || 'https://majstr.xyz';
+
+// Accept only the deep-link-encoded sources; anything else is recorded as
+// 'unknown' so a bad client value can never poison the growth-gate split.
+function normalizeSource(s) {
+  return MasterClaim.SOURCES.includes(s) ? s : 'unknown';
+}
 
 function normalizePhone(p) {
   return String(p).replace(/[^\d]/g, '');
@@ -42,7 +50,7 @@ function phoneMatches(claimantPhone, masterContacts) {
 }
 
 async function submitClaim(req, res) {
-  const { masterID, phone, notes } = req.body || {};
+  const { masterID, phone, notes, source } = req.body || {};
 
   if (!masterID) return res.status(400).json({ error: 'masterID required' });
   if (!mongoose.Types.ObjectId.isValid(masterID)) {
@@ -99,6 +107,7 @@ async function submitClaim(req, res) {
       claimantTelegramID: req.user.telegramID,
       evidence,
       status: autoApproved ? 'approved' : 'pending',
+      source: normalizeSource(source),
       autoApproved,
     });
   } catch (err) {
@@ -173,7 +182,12 @@ async function submitClaim(req, res) {
     }
   }
 
-  return res.status(201).json({ claim, autoApproved });
+  // The public card URL the new owner shares — the per-master OG image unfurls
+  // from this page (the share loop's engine). Valid whether the claim was
+  // auto-approved or queued; the card is already public either way.
+  const shareUrl = masterWebUrl(master, 'uk', PUBLIC_WEB_URL);
+
+  return res.status(201).json({ claim, autoApproved, shareUrl });
 }
 
 async function getMyClaims(req, res) {

--- a/backend/routes/draft.js
+++ b/backend/routes/draft.js
@@ -3,6 +3,7 @@ const MasterAudit = require('../database/schema/MasterAudit');
 const Profession = require('../database/schema/Profession');
 const Location = require('../database/schema/Location');
 const createOGimageForMaster = require('../helpers/generateOpenGraph');
+const { masterWebUrl } = require('../helpers/masterUrl');
 const { localizedName } = require('../lang');
 const { bot } = require('../bot');
 
@@ -270,7 +271,13 @@ async function submitDraft(req, res) {
 async function getMine(req, res) {
   const masters = await Master.find({ ownerUserID: req.user._id })
     .sort({ updatedAt: -1 });
-  res.json({ masters });
+  // Attach the public share URL so owners can one-tap-share their card (the
+  // per-master OG image unfurls from this page).
+  const withShare = masters.map((m) => ({
+    ...m.toObject(),
+    shareUrl: masterWebUrl(m, 'uk', PUBLIC_WEB_URL),
+  }));
+  res.json({ masters: withShare });
 }
 
 module.exports = { getDraft, patchDraft, deleteDraft, submitDraft, getMine };

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,2 +1,5 @@
 VITE_API_URL=https://api.majstr.xyz
 VITE_APP_URL=https://majstr.xyz
+# GA4 Measurement ID (same as the web app — one shared property).
+# When set, gtag loads in the Telegram Mini App and claim/submit/share events fire.
+VITE_GA4_ID=G-V2TNM71Q6G

--- a/frontend/src/analytics.ts
+++ b/frontend/src/analytics.ts
@@ -1,0 +1,38 @@
+// GA4 (gtag) for the Telegram Mini App. The TMA and the public web site share
+// one GA4 property. Events fire only when VITE_GA4_ID is configured, so call
+// sites never need to guard. initAnalytics() injects the gtag base snippet once
+// at app startup; track() emits a custom event.
+//
+// NOTE: Telegram in-app webviews can restrict third-party requests. If GA4
+// events don't appear in DebugView from inside Telegram, the claim/submit funnel
+// is also persisted server-side (claim `source`), so the Day-4 gate survives.
+type Params = Record<string, unknown>;
+
+const GA_ID = (import.meta.env as Record<string, string | undefined>).VITE_GA4_ID;
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+    dataLayer?: unknown[];
+  }
+}
+
+export function initAnalytics(): void {
+  if (!GA_ID || typeof window === "undefined" || window.gtag) return;
+  const s = document.createElement("script");
+  s.async = true;
+  s.src = `https://www.googletagmanager.com/gtag/js?id=${GA_ID}`;
+  document.head.appendChild(s);
+  window.dataLayer = window.dataLayer || [];
+  window.gtag = function gtag() {
+    // eslint-disable-next-line prefer-rest-params
+    window.dataLayer!.push(arguments);
+  };
+  window.gtag("js", new Date());
+  window.gtag("config", GA_ID);
+}
+
+export function track(event: string, params: Params = {}): void {
+  if (typeof window === "undefined") return;
+  window.gtag?.("event", event, params);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,7 +6,10 @@ import { router } from "./router";
 import { TelegramContextProvider } from "./surface/useTelegramContext";
 import { PopupProvider } from "./ui/usePopup";
 import { ThemeBridge } from "./ui/ThemeBridge";
+import { initAnalytics } from "./analytics";
 import "./ui/tokens.css";
+
+initAnalytics();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/frontend/src/onboarding/OnboardingWizard.tsx
+++ b/frontend/src/onboarding/OnboardingWizard.tsx
@@ -16,6 +16,7 @@ import { StepBioTags } from "./steps/StepBioTags";
 import { StepContact } from "./steps/StepContact";
 import { useHaptic } from "../ui/useHaptic";
 import { useClaimDeepLink } from "../surface/useClaimDeepLink";
+import { track } from "../analytics";
 import { OnboardingI18nProvider, useOnbT } from "./i18n";
 
 const STEP_TITLE_KEYS = [
@@ -71,6 +72,11 @@ function WizardInner() {
     const result = await submit();
     if (result.ok) {
       haptic.notify("success");
+      const v = form.getValues();
+      track("master_submit", {
+        profession_id: v.professionID,
+        location_id: v.locationID,
+      });
       setSubmitted(true);
       return;
     }

--- a/frontend/src/pages/ClaimCard.tsx
+++ b/frontend/src/pages/ClaimCard.tsx
@@ -1,21 +1,34 @@
 import "../onboarding/wizard.css";
 import { useEffect, useRef, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { apiFetch } from "../api/client";
 import { isTMA } from "../surface/detect";
+import { track } from "../analytics";
+
+// Map the deep-link ?src= suffix to the claim source recorded by the API +
+// analytics. Founder-DM links carry -dm; the public card CTA carries -org.
+function resolveSource(src: string | null): "founder_dm" | "organic" | "unknown" {
+  if (src === "dm") return "founder_dm";
+  if (src === "org") return "organic";
+  return "unknown";
+}
+
+const SHARE_TEXT = "Я тепер у каталозі Majstr — знайдете мене тут 👉";
 
 // Landing screen for the share-to-claim deep link
 // (t.me/<bot>?startapp=claim-<masterId>). Standalone, styled like the
 // add-master wizard — no website header/branding.
 type ClaimState =
   | { phase: "checking" }
-  | { phase: "success" }
+  | { phase: "success"; shareUrl?: string }
   | { phase: "pending" }
   | { phase: "deleted" }
   | { phase: "error"; message: string };
 
 export default function ClaimCard() {
   const { masterId } = useParams<{ masterId: string }>();
+  const [searchParams] = useSearchParams();
+  const source = resolveSource(searchParams.get("src"));
   const navigate = useNavigate();
   const [state, setState] = useState<ClaimState>({ phase: "checking" });
   const [deleting, setDeleting] = useState(false);
@@ -24,6 +37,8 @@ export default function ClaimCard() {
   useEffect(() => {
     if (!masterId || fired.current) return;
     fired.current = true; // claims are rate-limited — never double-fire
+
+    track("claim_start", { master_id: masterId, source });
 
     (async () => {
       if (!isTMA()) {
@@ -40,14 +55,20 @@ export default function ClaimCard() {
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ masterID: masterId }),
+            body: JSON.stringify({ masterID: masterId, source }),
           },
           { redirectOn401: false }
         );
 
         if (res.status === 201) {
-          const { autoApproved } = await res.json();
-          setState({ phase: autoApproved ? "success" : "pending" });
+          const { autoApproved, shareUrl } = await res.json();
+          if (autoApproved) {
+            track("claim_success", { master_id: masterId, source, auto_approved: true });
+            setState({ phase: "success", shareUrl });
+          } else {
+            track("claim_pending", { master_id: masterId, source });
+            setState({ phase: "pending" });
+          }
           return;
         }
 
@@ -94,7 +115,23 @@ export default function ClaimCard() {
         setState({ phase: "error", message: "Немає звʼязку. Спробуйте ще раз." });
       }
     })();
-  }, [masterId, navigate]);
+  }, [masterId, source, navigate]);
+
+  function handleShare(shareUrl?: string) {
+    if (!shareUrl) return;
+    track("share_click", { master_id: masterId, share_method: "claim_success" });
+    const tg = window.Telegram?.WebApp;
+    // Prefer Telegram's native share sheet inside the Mini App; fall back to the
+    // Web Share API, then to opening the t.me share URL.
+    const tgShare = `https://t.me/share/url?url=${encodeURIComponent(shareUrl)}&text=${encodeURIComponent(SHARE_TEXT)}`;
+    if (tg?.openTelegramLink) {
+      tg.openTelegramLink(tgShare);
+    } else if (navigator.share) {
+      navigator.share({ text: SHARE_TEXT, url: shareUrl }).catch(() => {});
+    } else {
+      window.open(tgShare, "_blank");
+    }
+  }
 
   async function handleDelete() {
     if (!window.confirm("Видалити картку назавжди? Цю дію не можна скасувати.")) return;
@@ -126,9 +163,18 @@ export default function ClaimCard() {
             отримає позначку VERIFIED і показуватиметься вище в пошуку.
           </p>
           <div className="wizard-actions" style={{ width: "100%", maxWidth: 320 }}>
+            {state.shareUrl && (
+              <button
+                type="button"
+                className="wizard-solid-btn"
+                onClick={() => handleShare(state.shareUrl)}
+              >
+                Поділитися карткою 🔗
+              </button>
+            )}
             <button
               type="button"
-              className="wizard-solid-btn"
+              className={state.shareUrl ? "wizard-ghost-btn" : "wizard-solid-btn"}
               onClick={() => navigate("/my-cards")}
             >
               Редагувати картку

--- a/frontend/src/pages/MyCards.tsx
+++ b/frontend/src/pages/MyCards.tsx
@@ -4,6 +4,7 @@ import { Navigate } from "react-router-dom";
 import { apiFetch } from "../api/client";
 import { localizedName } from "../i18n/lang";
 import { isTMA } from "../surface/detect";
+import { track } from "../analytics";
 import { useReferenceData, type Profession, type ProfCategory, type Location } from "../onboarding/useReferenceData";
 import { PickerSheet } from "../onboarding/ui/PickerSheet";
 import { LANGUAGE_OPTIONS } from "../onboarding/schema";
@@ -25,9 +26,23 @@ type OwnedMaster = {
   photo?: string | null;
   tags?: { ua?: string[]; en?: string[] };
   languages?: string[];
+  shareUrl?: string;
 };
 
 const CONTACT_TYPES = ["telegram", "whatsapp", "phone", "instagram", "facebook", "email"];
+
+const SHARE_TEXT = "Я тепер у каталозі Majstr — знайдете мене тут 👉";
+
+// Share the card's public page (its per-master OG image unfurls in Telegram).
+function shareCard(master: { _id: string; shareUrl?: string }) {
+  if (!master.shareUrl) return;
+  track("share_click", { master_id: master._id, share_method: "my_cards" });
+  const tg = window.Telegram?.WebApp;
+  const tgShare = `https://t.me/share/url?url=${encodeURIComponent(master.shareUrl)}&text=${encodeURIComponent(SHARE_TEXT)}`;
+  if (tg?.openTelegramLink) tg.openTelegramLink(tgShare);
+  else if (navigator.share) navigator.share({ text: SHARE_TEXT, url: master.shareUrl }).catch(() => {});
+  else window.open(tgShare, "_blank");
+}
 
 const STATUS_LABEL: Record<string, string> = {
   approved: "Опубліковано",
@@ -204,6 +219,15 @@ function CardManage({ master, professions, profCategories, locations, onUpdate, 
 
       {!editing && (
         <div className="wizard-actions">
+          {master.shareUrl && (
+            <button
+              type="button"
+              className="wizard-ghost-btn wizard-ghost-btn--primary"
+              onClick={() => shareCard(master)}
+            >
+              Поділитися 🔗
+            </button>
+          )}
           <button
             type="button"
             className="wizard-ghost-btn wizard-ghost-btn--primary"

--- a/frontend/src/surface/telegram-global.d.ts
+++ b/frontend/src/surface/telegram-global.d.ts
@@ -75,6 +75,8 @@ export interface TgWebApp {
   ready(): void;
   expand(): void;
   close(): void;
+  openTelegramLink?(url: string): void;
+  openLink?(url: string, options?: { try_instant_view?: boolean }): void;
   onEvent(event: string, cb: () => void): void;
   offEvent(event: string, cb: () => void): void;
   CloudStorage?: TgCloudStorage;

--- a/frontend/src/surface/useClaimDeepLink.ts
+++ b/frontend/src/surface/useClaimDeepLink.ts
@@ -11,8 +11,14 @@ export function useClaimDeepLink(): void {
 
   useEffect(() => {
     const sp = window.Telegram?.WebApp?.initDataUnsafe?.start_param;
-    const m = sp?.match(/^claim[-_]([0-9a-f]{24})$/i);
-    if (m) navigate(`/claim/${m[1]}`, { replace: true });
+    // claim-<24hex> with an optional -dm / -org source suffix. The suffix tags
+    // the claim as founder-driven vs organic for the Day-4 growth gate; it's
+    // carried to /claim as ?src= and forwarded to the API + analytics.
+    const m = sp?.match(/^claim[-_]([0-9a-f]{24})(?:[-_](dm|org))?$/i);
+    if (m) {
+      const src = m[2] ? `?src=${m[2].toLowerCase()}` : "";
+      navigate(`/claim/${m[1]}${src}`, { replace: true });
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 }

--- a/web/.env.example
+++ b/web/.env.example
@@ -12,3 +12,13 @@ SPA_ORIGIN=
 # Shared secret for POST /api/revalidate (set the SAME value in the Telegram bot
 # so master approval triggers on-demand ISR).
 REVALIDATE_SECRET=
+
+# GA4 Measurement ID. Optional — layout.tsx already defaults to G-V2TNM71Q6G in
+# production builds; set this only to override (e.g. a separate staging property).
+NEXT_PUBLIC_GA4_ID=
+
+# Search-engine ownership tokens (rendered into <meta> by app/layout.tsx).
+# Get GOOGLE_SITE_VERIFICATION from Google Search Console, YANDEX_VERIFICATION
+# from Yandex Webmaster. Then submit https://majstr.xyz/sitemap.xml in both.
+GOOGLE_SITE_VERIFICATION=
+YANDEX_VERIFICATION=

--- a/web/app/[lang]/[city]/page.tsx
+++ b/web/app/[lang]/[city]/page.tsx
@@ -9,6 +9,7 @@ import {
   cityPrep,
 } from "@/lib/data";
 import { buildSeed } from "@/lib/seed";
+import { cityHubDescription, professionHubDescription } from "@/lib/content";
 import { abs } from "@/lib/urls";
 import AppShell from "@/spa/AppShell";
 import Main from "@/spa/pages/Main";
@@ -61,11 +62,13 @@ export async function generateMetadata({
         : lang === "en"
           ? `Ukrainian- & Russian-speaking masters ${cityPrep(city, lang)} | Majstr`
           : `Україномовні майстри ${cityPrep(city, lang)} | Majstr`;
+    const description = cityHubDescription(lang, cityPrep(city, lang));
     return {
       title,
+      description,
       robots: isIndexable(lang) ? undefined : { index: false, follow: true },
       alternates: { canonical: abs(`/${lang}/${city.id}`), languages: langAlt(city.id) },
-      openGraph: { title, locale: OG_LOCALE[lang], type: "website" },
+      openGraph: { title, description, locale: OG_LOCALE[lang], type: "website" },
     };
   }
   const { lang, cat } = r;
@@ -76,11 +79,13 @@ export async function generateMetadata({
       : lang === "en"
         ? `${catName} in Italy — Ukrainian-speaking masters | Majstr`
         : `${catName} в Італії — україномовні майстри | Majstr`;
+  const description = professionHubDescription(lang, catName);
   return {
     title,
+    description,
     robots: isIndexable(lang) ? undefined : { index: false, follow: true },
     alternates: { canonical: abs(`/${lang}/${cat.id}`), languages: langAlt(cat.id) },
-    openGraph: { title, locale: OG_LOCALE[lang], type: "website" },
+    openGraph: { title, description, locale: OG_LOCALE[lang], type: "website" },
   };
 }
 

--- a/web/app/[lang]/layout.tsx
+++ b/web/app/[lang]/layout.tsx
@@ -56,6 +56,12 @@ const jetbrains = JetBrains_Mono({
 const fontVars = `${archivo.variable} ${golos.variable} ${dmSans.variable} ${jetbrains.variable}`;
 
 const GTM_ID = "GTM-MB2CPXFD";
+// Direct GA4 (gtag). The measurement ID is public (it ships in client JS), so a
+// production default is fine; env can override per-deploy. Gated to production so
+// local `next dev` doesn't pollute the GA4 property. GTM still loads independently.
+const GA4_ID =
+  process.env.NEXT_PUBLIC_GA4_ID ||
+  (process.env.NODE_ENV === "production" ? "G-V2TNM71Q6G" : undefined);
 
 // This layout owns <html>/<body> so the `lang` attribute reflects the URL
 // locale (uk/ru/en) — the root layout is above the [lang] segment and can't
@@ -85,6 +91,18 @@ export default async function LangLayout({
             style={{ display: "none", visibility: "hidden" }}
           />
         </noscript>
+        {/* GA4 (gtag) — conversion events fire via track() in lib/analytics.ts */}
+        {GA4_ID && (
+          <>
+            <Script
+              src={`https://www.googletagmanager.com/gtag/js?id=${GA4_ID}`}
+              strategy="afterInteractive"
+            />
+            <Script id="ga4" strategy="afterInteractive">
+              {`window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','${GA4_ID}');`}
+            </Script>
+          </>
+        )}
         {children}
       </body>
     </html>

--- a/web/app/[lang]/page.tsx
+++ b/web/app/[lang]/page.tsx
@@ -22,6 +22,14 @@ function homeTitle(lang: Lang) {
   return "Україно- та російськомовні майстри в Італії | Majstr";
 }
 
+function homeDescription(lang: Lang) {
+  if (lang === "ru")
+    return "Majstr — каталог проверенных русско- и украиноязычных мастеров в Италии: маникюр, парикмахеры, косметологи, электрики, врачи и другие. Запись в Telegram, бесплатно.";
+  if (lang === "en")
+    return "Majstr — directory of trusted Ukrainian- and Russian-speaking masters in Italy: manicurists, hairdressers, beauticians, electricians, doctors and more. Book on Telegram, free.";
+  return "Majstr — каталог перевірених україно- та російськомовних майстрів в Італії: манікюр, перукарі, косметологи, електрики, лікарі та інші. Запис у Telegram, безкоштовно.";
+}
+
 // NOTE: deliberately does NOT read searchParams. Reading searchParams here opts
 // the whole route out of static generation, forcing a per-request serverless
 // render (x-vercel-cache: MISS, ~0.5-1s TTFB, no edge caching). The legacy
@@ -37,14 +45,16 @@ export async function generateMetadata({
   const { lang } = await params;
   if (!isLang(lang)) return {};
   const title = homeTitle(lang);
+  const description = homeDescription(lang);
   return {
     title,
+    description,
     robots: isIndexable(lang) ? undefined : { index: false, follow: true },
     alternates: {
       canonical: abs(homePath(lang)),
       languages: languageAlternates((l) => homePath(l)),
     },
-    openGraph: { title, url: abs(homePath(lang)), locale: OG_LOCALE[lang], type: "website" },
+    openGraph: { title, description, url: abs(homePath(lang)), locale: OG_LOCALE[lang], type: "website" },
   };
 }
 

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -17,6 +17,13 @@ export const metadata: Metadata = {
   openGraph: { type: "website", siteName: "Majstr" },
   twitter: { card: "summary_large_image" },
   icons: { icon: "/favicon.png" },
+  // Search Console + Yandex Webmaster ownership. Tokens come from env (set in
+  // Vercel); when absent the tags are simply omitted. Yandex matters as much as
+  // Google here — it's where the RU diaspora pages are meant to rank.
+  verification: {
+    google: process.env.GOOGLE_SITE_VERIFICATION,
+    yandex: process.env.YANDEX_VERIFICATION,
+  },
 };
 
 // <html>/<body> live in app/[lang]/layout.tsx so the `lang` attribute can

--- a/web/lib/analytics.ts
+++ b/web/lib/analytics.ts
@@ -1,0 +1,11 @@
+// Thin GA4 (gtag) event wrapper for the public site. The gtag base snippet is
+// loaded in app/[lang]/layout.tsx only when NEXT_PUBLIC_GA4_ID is set, so this
+// is a no-op until analytics is configured — call sites never need to guard.
+type Params = Record<string, unknown>;
+
+type GtagWindow = Window & { gtag?: (...args: unknown[]) => void };
+
+export function track(event: string, params: Params = {}): void {
+  if (typeof window === "undefined") return;
+  (window as GtagWindow).gtag?.("event", event, params);
+}

--- a/web/lib/i18n.ts
+++ b/web/lib/i18n.ts
@@ -16,7 +16,9 @@ export function isLang(x: string): x is Lang {
 // hreflang and marked noindex per page — so we never publish thin/duplicate
 // pages. One switch drives sitemap inclusion, hreflang inclusion, and the
 // per-page robots flag. Flip to true once English template copy is authored.
-export const EN_INDEXED = true;
+// 2026-06-16: set false for launch — EN body copy is still template-thin, so we
+// keep /en routes reachable but out of the index to avoid thin duplicate pages.
+export const EN_INDEXED = false;
 
 // Locales advertised to crawlers (sitemap entries + hreflang alternates).
 // While `en` is gated it stays out of this list but its routes still render.

--- a/web/lib/seed.ts
+++ b/web/lib/seed.ts
@@ -24,6 +24,7 @@ type SlimMaster = Pick<
   | "photo"
   | "tags"
   | "verified"
+  | "claimable"
 >;
 
 function slimMaster(m: Master): SlimMaster {
@@ -38,6 +39,9 @@ function slimMaster(m: Master): SlimMaster {
     tags: m.tags,
     // Needed by the grid: VERIFIED badge + verified-first ordering.
     verified: m.verified,
+    // Needed by the modal: the logged-out "claim this card" CTA renders on any
+    // claimable (unowned, scraped) card — the self-Googling-master acquisition path.
+    claimable: m.claimable,
   };
 }
 

--- a/web/spa/components/Modal.tsx
+++ b/web/spa/components/Modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useContext, useEffect, useMemo, useState } from "react";
+import { useContext, useEffect, useMemo } from "react";
 import Image from "next/image";
 import { MasterContext } from "../context";
 import { useTranslation } from "../custom-hooks/useTranslation";
@@ -8,6 +8,7 @@ import { localizedName } from "../i18n/lang";
 import { transliterate } from "../helpers/transliterate";
 import Sigil from "./Sigil";
 import { masterSlug } from "@/lib/data";
+import { track } from "@/lib/analytics";
 
 import type { Master, Contacts } from "../schema/master/master.schema";
 import { Location, Profession } from "../schema/state/state.schema";
@@ -136,16 +137,12 @@ export default function Modal({ master, setShowModal, loadingDetails }: ModalPro
 
   const useTwoColContacts = contacts.length >= 4;
 
-  // Share-to-claim: a shared card link may carry a #claim (or ?claim=1)
-  // marker. Capture it during the FIRST render — the URL-mirroring effect
-  // below rewrites the URL (pushState) and would wipe the hash.
-  const [claimIntent] = useState(
-    () =>
-      typeof window !== "undefined" &&
-      (window.location.hash === "#claim" ||
-        new URLSearchParams(window.location.search).get("claim") === "1")
-  );
-  const showClaimBanner = claimIntent && master.claimable === true;
+  // "Це ваша картка? Заберіть її" — shown on every claimable (unowned, scraped)
+  // card, logged out, no URL flag required. This IS the acquisition channel: a
+  // master who Googles their own name lands here and can claim in two taps. The
+  // `-org` deep-link suffix tags the resulting claim as organic (vs founder-DM)
+  // for the Day-4 growth gate.
+  const showClaimBanner = master.claimable === true;
   const botUsername = process.env.NEXT_PUBLIC_TMA_BOT_USERNAME || "majstr_bot";
 
   // While the modal is open, reflect it in the URL as the master page
@@ -181,10 +178,12 @@ export default function Modal({ master, setShowModal, loadingDetails }: ModalPro
             </button>
           </header>
 
-          {/* Share-to-claim banner (link carried #claim / ?claim=1) */}
+          {/* "Це ваша картка? Заберіть її" — logged-out claim CTA on every
+              claimable scraped card (the self-Googling-master acquisition path). */}
           {showClaimBanner && (
             <a
-              href={`https://t.me/${botUsername}?startapp=claim-${id}`}
+              href={`https://t.me/${botUsername}?startapp=claim-${id}-org`}
+              onClick={() => track("claim_cta_click", { master_id: id, source: "organic" })}
               style={{
                 display: "flex",
                 alignItems: "center",
@@ -203,7 +202,7 @@ export default function Modal({ master, setShowModal, loadingDetails }: ModalPro
                 textAlign: "center",
               }}
             >
-              Це ваша картка? Натисніть, щоб редагувати або видалити →
+              Це ваша картка? Заберіть її безкоштовно →
             </a>
           )}
 
@@ -247,6 +246,24 @@ export default function Modal({ master, setShowModal, loadingDetails }: ModalPro
                   <span className="modal-master__profession">{profName}</span>
                   <span className="modal-master__divider" aria-hidden="true" />
                   <span className="modal-master__city">{locName}</span>
+                  {master.verified && (
+                    <span
+                      style={{
+                        marginLeft: 8,
+                        background: "var(--terra)",
+                        color: "var(--paper)",
+                        fontFamily: "var(--font-mono)",
+                        fontSize: 9,
+                        fontWeight: 700,
+                        letterSpacing: "0.1em",
+                        textTransform: "uppercase",
+                        padding: "2px 6px",
+                        borderRadius: 2,
+                      }}
+                    >
+                      ✓ Verified
+                    </span>
+                  )}
                 </div>
               </div>
 
@@ -293,6 +310,13 @@ export default function Modal({ master, setShowModal, loadingDetails }: ModalPro
                         href={meta.href(c.value)}
                         target={c.contactType === "phone" || c.contactType === "email" ? undefined : "_blank"}
                         rel="noopener noreferrer"
+                        onClick={() =>
+                          track("contact_click", {
+                            master_id: id,
+                            channel: c.contactType.toLowerCase(),
+                            is_primary: false,
+                          })
+                        }
                       >
                         <span className="modal-master__contact-label">{meta.label}</span>
                         <span className="modal-master__contact-value">{meta.display(c.value)}</span>
@@ -328,6 +352,13 @@ export default function Modal({ master, setShowModal, loadingDetails }: ModalPro
                 href={primaryHref}
                 target={primaryContact.contactType === "phone" || primaryContact.contactType === "email" ? undefined : "_blank"}
                 rel="noopener noreferrer"
+                onClick={() =>
+                  track("contact_click", {
+                    master_id: id,
+                    channel: primaryContact.contactType.toLowerCase(),
+                    is_primary: true,
+                  })
+                }
               >
                 <span className="modal-master__cta-label">{ctaText}</span>
                 <span className="modal-master__cta-arrow" aria-hidden="true">→</span>


### PR DESCRIPTION
Implements the P0/P1 fixes from the 2026-06-16 launch-readiness audit so Milan outreach can start. Merging this to **main** redeploys **both** Vercel apps (web/ + frontend/) to production.

## Conversion loop
- Logged-out **"Це ваша картка? Заберіть її"** CTA on every claimable card — ungated from the old `#claim` flag; `claimable` re-added to the slim seed so grid-opened cards work too.
- **One-tap share** on the claim-success screen + per card in My Cards. Backend returns a `shareUrl` (`POST /api/claims`, `GET /api/masters/mine`) so the per-master OG image unfurls in Telegram.
- **Verified badge** now renders in the public card modal.

## Analytics — direct GA4 (gtag)
- `track()` in web + TMA; gtag loads only in production / when the id is set (`G-V2TNM71Q6G`).
- Events: `claim_start`, `claim_success` (+`source`, `auto_approved`), `claim_pending`, `master_submit`, `share_click`, `contact_click`, `claim_cta_click`.
- `-dm`/`-org` deep-link suffix → `source`, parsed client-side **and persisted on `MasterClaim.source`**, so the Day-4 founder-vs-organic gate survives even if gtag is blocked in the Telegram webview.

## SEO
- `EN_INDEXED = false` (keep /en reachable but out of the index until copy is authored).
- Google + Yandex `verification` read from env (already verified another way — env optional).
- Wired the written-but-unused hub + home meta descriptions.

## Verification
- web `tsc` clean · frontend `typecheck` clean · frontend lint: 9 pre-existing warnings, 0 new · backend tests 168/168.

## Post-merge (manual, see runbook)
GA4: referral exclusions (done) + mark `claim_success`/`master_submit`/`contact_click` as key events after they first fire · submit sitemaps · Telegram DebugView check · OG unfurl paste-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)