### PR TITLE
fix(bot): clear approval buttons after admin decision

### DIFF
--- a/backend/bot/editAdminMessage.js
+++ b/backend/bot/editAdminMessage.js
@@ -1,0 +1,21 @@
+const { bot } = require('./instance');
+
+// Finalize an admin decision in the admin chat: append a status line to the
+// request message AND remove its inline keyboard so the Verify/Approve/Decline
+// buttons can't be tapped again.
+//
+// Verification and moderation requests are sent via sendPhoto when the master
+// has a photo (so the message has a `caption`, not `text`). editMessageText
+// fails on a photo message — which is why the buttons used to stay put — so we
+// branch on the message type. Omitting reply_markup clears the inline keyboard
+// in both edit calls. Errors are swallowed (the decision already succeeded).
+function editAdminMessage(message, suffix) {
+  const body = `${message.text || message.caption || ''}\n\n${suffix}`;
+  const opts = { chat_id: message.chat.id, message_id: message.message_id };
+  return (message.caption != null
+    ? bot.editMessageCaption(body, opts)
+    : bot.editMessageText(body, opts)
+  ).catch(() => {});
+}
+
+module.exports = { editAdminMessage };

--- a/backend/bot/moderationCallbacks.js
+++ b/backend/bot/moderationCallbacks.js
@@ -4,6 +4,7 @@ const User = require('../database/schema/User');
 const i18n = require('../i18n');
 const { masterWebUrl } = require('../helpers/masterUrl');
 const { bot, getUserLang, REVALIDATE_SECRET, PUBLIC_WEB_URL } = require('./instance');
+const { editAdminMessage } = require('./editAdminMessage');
 
 async function handleMasterCallback(queryId, message, data, from) {
   // data format: master:approve:<masterID> or master:decline:<masterID>
@@ -18,10 +19,7 @@ async function handleMasterCallback(queryId, message, data, from) {
   }
   if (master.status !== 'pending') {
     await bot.answerCallbackQuery(queryId, { text: `Вже ${master.status}` });
-    return bot.editMessageText(`${message.text}\n\nℹ️ Вже оброблено (${master.status}).`, {
-      chat_id: message.chat.id,
-      message_id: message.message_id,
-    }).catch(() => {});
+    return editAdminMessage(message, `ℹ️ Вже оброблено (${master.status}).`);
   }
 
   const adminUser = await User.findOne({ telegramID: from.id });
@@ -42,10 +40,7 @@ async function handleMasterCallback(queryId, message, data, from) {
     }).catch(err => console.error('Failed to write approve audit row:', err));
 
     await bot.answerCallbackQuery(queryId, { text: '✅ Схвалено' });
-    await bot.editMessageText(
-      `${message.text}\n\n✅ Схвалено — ${from.first_name}`,
-      { chat_id: message.chat.id, message_id: message.message_id }
-    ).catch(() => {});
+    await editAdminMessage(message, `✅ Схвалено — ${from.first_name}`);
 
     // Flush the Next.js ISR cache so the new master page is live immediately.
     // Awaited so the cache is warm before the notification URL is sent.
@@ -79,10 +74,7 @@ async function handleMasterCallback(queryId, message, data, from) {
     }).catch(err => console.error('Failed to write reject audit row:', err));
 
     await bot.answerCallbackQuery(queryId, { text: '❌ Відхилено' });
-    await bot.editMessageText(
-      `${message.text}\n\n❌ Відхилено — ${from.first_name}`,
-      { chat_id: message.chat.id, message_id: message.message_id }
-    ).catch(() => {});
+    await editAdminMessage(message, `❌ Відхилено — ${from.first_name}`);
 
     if (master.telegramID) {
       const oLang = await getUserLang(master.telegramID);

--- a/backend/bot/verifyCallbacks.js
+++ b/backend/bot/verifyCallbacks.js
@@ -5,6 +5,7 @@ const i18n = require('../i18n');
 const createOGimageForMaster = require('../helpers/generateOpenGraph');
 const { masterWebUrl } = require('../helpers/masterUrl');
 const { bot, getUserLang, REVALIDATE_SECRET, PUBLIC_WEB_URL } = require('./instance');
+const { editAdminMessage } = require('./editAdminMessage');
 
 // verify:approve:<masterID> / verify:decline:<masterID> — moderator decision
 // on a verification request (helpers/verification.js). Approve grants the
@@ -22,11 +23,6 @@ async function handleVerifyCallback(queryId, message, data, from) {
   }
 
   const adminUser = await User.findOne({ telegramID: from.id });
-  const editText = (suffix) =>
-    bot.editMessageText(`${message.text || message.caption || ''}\n\n${suffix}`, {
-      chat_id: message.chat.id,
-      message_id: message.message_id,
-    }).catch(() => {});
 
   if (action === 'approve') {
     if (master.verified) {
@@ -46,7 +42,7 @@ async function handleVerifyCallback(queryId, message, data, from) {
     }).catch(err => console.error('Failed to write verify audit row:', err));
 
     await bot.answerCallbackQuery(queryId, { text: '✅ Верифіковано' });
-    await editText(`✅ Верифіковано — ${from.first_name}`);
+    await editAdminMessage(message, `✅ Верифіковано — ${from.first_name}`);
 
     // Refresh the OG card (verified stamp) and the public pages.
     createOGimageForMaster(master)
@@ -76,7 +72,7 @@ async function handleVerifyCallback(queryId, message, data, from) {
     }).catch(err => console.error('Failed to write verify audit row:', err));
 
     await bot.answerCallbackQuery(queryId, { text: '❌ Відхилено' });
-    await editText(`❌ Верифікацію відхилено — ${from.first_name}`);
+    await editAdminMessage(message, `❌ Верифікацію відхилено — ${from.first_name}`);
 
     if (master.telegramID) {
       const oLang = await getUserLang(master.telegramID);

--- a/backend/test/bot/verifyCallbacks.test.js
+++ b/backend/test/bot/verifyCallbacks.test.js
@@ -24,6 +24,7 @@ beforeEach(() => {
   vi.spyOn(bot, 'sendPhoto').mockResolvedValue({});
   vi.spyOn(bot, 'answerCallbackQuery').mockResolvedValue(true);
   vi.spyOn(bot, 'editMessageText').mockResolvedValue({});
+  vi.spyOn(bot, 'editMessageCaption').mockResolvedValue({});
 });
 
 afterEach(async () => {
@@ -89,6 +90,23 @@ describe('handleVerifyCallback — approve', () => {
     expect(bot.sendMessage).toHaveBeenCalledWith(70042, expect.stringContaining('VERIFIED'));
     // OG card regenerated with the verified stamp
     await vi.waitFor(() => expect(ogMock).toHaveBeenCalled());
+  });
+
+  it('clears the buttons on a photo request by editing the caption, not the text', async () => {
+    // Photo verification requests carry a caption, not text — editMessageText
+    // fails on them, which used to leave the Verify/Decline buttons tappable.
+    const master = await Master.create({ name: 'Олена', status: 'approved' });
+    const photoMessage = { chat: { id: 424242 }, message_id: 88, caption: 'Запит на верифікацію' };
+
+    await handleVerifyCallback('q6', photoMessage, `verify:approve:${master._id}`, admin);
+
+    expect(bot.editMessageCaption).toHaveBeenCalledTimes(1);
+    const [body, opts] = bot.editMessageCaption.mock.calls[0];
+    expect(body).toContain('✅ Верифіковано');
+    expect(opts).toMatchObject({ chat_id: 424242, message_id: 88 });
+    // No reply_markup passed → Telegram removes the inline keyboard.
+    expect(opts.reply_markup).toBeUndefined();
+    expect(bot.editMessageText).not.toHaveBeenCalled();
   });
 
   it('answers idempotently when the card is already verified', async () => {


### PR DESCRIPTION
**Bug:** in `majstr_bot`, the Verify/Decline (and Approve/Decline) inline buttons didn't disappear after the admin tapped them.

**Cause:** verification/moderation requests are sent via `sendPhoto` when the master has a photo, so the message carries a **caption, not text**. `editMessageText` fails on a photo message and the error was swallowed — caption never updated and the keyboard stayed live.

**Fix:** shared `editAdminMessage()` helper — edits the caption for photo messages, the text otherwise; omitting `reply_markup` clears the inline keyboard in both. Wired into `verifyCallbacks` + `moderationCallbacks` (same latent bug). Regression test added.

Backend tests: 169/169. Deploys via **Railway** (backend/bot), not Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)