### PR TITLE
Localize verified badge (uppercase) + OG backfill script

### DIFF
--- a/backend/scripts/backfill-og-images.js
+++ b/backend/scripts/backfill-og-images.js
@@ -1,0 +1,80 @@
+'use strict';
+
+/**
+ * Regenerate OG images for all approved masters using the Playwright-based
+ * generator (og-template.html → PNG → S3), then update Master.OGimage.
+ *
+ * Dry-run by default — shows what would be processed without generating.
+ *
+ * Usage (from backend/):
+ *   node scripts/backfill-og-images.js                        # dry run
+ *   node scripts/backfill-og-images.js --apply                # regenerate all
+ *   node scripts/backfill-og-images.js --apply --id <mongoId> # single master
+ */
+require('dotenv').config();
+const mongoose = require('mongoose');
+const { runDB } = require('../database/db');
+const Master = require('../database/schema/Master');
+const createOGimageForMaster = require('../helpers/generateOpenGraph');
+const { closeBrowser } = require('../helpers/generateOpenGraph');
+
+const APPLY   = process.argv.includes('--apply');
+const ID_FLAG = process.argv.indexOf('--id');
+const ONLY_ID = ID_FLAG !== -1 ? process.argv[ID_FLAG + 1] : null;
+
+async function main() {
+  await runDB();
+
+  const query = ONLY_ID ? { _id: ONLY_ID } : { status: 'approved' };
+  const masters = await Master.find(query)
+    .select('_id name professionID locationID languages photo about contacts approved verified countryID')
+    .lean();
+
+  console.log(`Found ${masters.length} master(s) to process.`);
+
+  if (!APPLY) {
+    const withPhoto = masters.filter(m => m.photo).length;
+    const noPhoto   = masters.length - withPhoto;
+    console.log(`  ${withPhoto} with photo → 600px visual column`);
+    console.log(`  ${noPhoto} without photo → mini-sigil column`);
+    console.log('\nDry run — pass --apply to generate and upload.');
+    await mongoose.disconnect();
+    return;
+  }
+
+  let ok = 0, fail = 0;
+  const errors = [];
+
+  for (let i = 0; i < masters.length; i++) {
+    const m = masters[i];
+    const label = `[${i + 1}/${masters.length}] ${m.name || String(m._id)}`;
+    process.stdout.write(`${label} ... `);
+
+    try {
+      const url = await createOGimageForMaster(m);
+      await Master.updateOne({ _id: m._id }, { $set: { OGimage: url.toString() } });
+      console.log('✓');
+      ok++;
+    } catch (err) {
+      console.log(`✗  ${err.message}`);
+      errors.push({ id: String(m._id), name: m.name, error: err.message });
+      fail++;
+    }
+  }
+
+  console.log(`\n────────────────────────────────`);
+  console.log(`Done. ${ok} succeeded, ${fail} failed.`);
+
+  if (errors.length) {
+    console.log('\nFailed masters:');
+    errors.forEach(e => console.log(`  ${e.id}  ${e.name}: ${e.error}`));
+  }
+
+  await closeBrowser();
+  await mongoose.disconnect();
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/web/spa/components/MasterCard.tsx
+++ b/web/spa/components/MasterCard.tsx
@@ -126,7 +126,7 @@ export default function MasterCard({ master, setShowModal, isNew }: MasterCardPr
                 className="master-card__badge master-card__badge--status master-card__badge--verified"
                 title={t("masterCard.verified")}
               >
-                VERIFIED
+                {t("masterCard.verifiedBadge")}
               </span>
             )}
             {statusBadge === "new" && (

--- a/web/spa/components/Modal.tsx
+++ b/web/spa/components/Modal.tsx
@@ -252,7 +252,7 @@ export default function Modal({ master, setShowModal, loadingDetails }: ModalPro
                     padding: "3px 6px",
                   }}
                 >
-                  ✓ Verified
+                  ✓ {t("masterCard.verifiedBadge")}
                 </span>
               )}
             </div>

--- a/web/spa/i18n/translations.ts
+++ b/web/spa/i18n/translations.ts
@@ -47,7 +47,7 @@ export type LangTranslations = {
   browse: { label: string; allCategories: string; browseLabel: string };
   results: { found: string; empty: string; emptyCity: string; tryChanging: string; sortedByRating: string };
   modal: { noAbout: string; languages: string; about: string; skills: string; contact: string };
-  masterCard: { details: string; noReviews: string; verified: string; memberSince: string };
+  masterCard: { details: string; noReviews: string; verified: string; verifiedBadge: string; memberSince: string };
   badge: { newThisWeek: string; recentlyAdded: string };
   cta: { microcopy: string };
   login: { loading: string; error: string; home: string };
@@ -117,7 +117,7 @@ export const translations: Record<string, LangTranslations> = {
       skills: "Навички",
       contact: "Зв'язатися",
     },
-    masterCard: { details: "OPEN", noReviews: "Поки немає відгуків", verified: "Профіль підтверджено", memberSince: "Учасник з" },
+    masterCard: { details: "OPEN", noReviews: "Поки немає відгуків", verified: "Профіль підтверджено", verifiedBadge: "Перевірено", memberSince: "Учасник з" },
     badge: { newThisWeek: "Новий цього тижня", recentlyAdded: "Щойно доданий" },
     cta: { microcopy: "3 хв · Безкоштовно · Telegram" },
     login: {
@@ -194,7 +194,7 @@ export const translations: Record<string, LangTranslations> = {
       skills: "Skills",
       contact: "Contact",
     },
-    masterCard: { details: "OPEN", noReviews: "No reviews yet", verified: "Profile verified", memberSince: "Member since" },
+    masterCard: { details: "OPEN", noReviews: "No reviews yet", verified: "Profile verified", verifiedBadge: "Verified", memberSince: "Member since" },
     badge: { newThisWeek: "New this week", recentlyAdded: "Recently added" },
     cta: { microcopy: "3 min · Free · Via Telegram" },
     login: {
@@ -271,7 +271,7 @@ export const translations: Record<string, LangTranslations> = {
       skills: "Competenze",
       contact: "Contatta",
     },
-    masterCard: { details: "OPEN", noReviews: "Nessuna recensione", verified: "Profilo verificato", memberSince: "Membro da" },
+    masterCard: { details: "OPEN", noReviews: "Nessuna recensione", verified: "Profilo verificato", verifiedBadge: "Verificato", memberSince: "Membro da" },
     badge: { newThisWeek: "Nuovo questa settimana", recentlyAdded: "Aggiunto di recente" },
     cta: { microcopy: "3 min · Gratis · Via Telegram" },
     login: {
@@ -348,7 +348,7 @@ export const translations: Record<string, LangTranslations> = {
       skills: "Competências",
       contact: "Contactar",
     },
-    masterCard: { details: "OPEN", noReviews: "Sem avaliações", verified: "Perfil verificado", memberSince: "Membro desde" },
+    masterCard: { details: "OPEN", noReviews: "Sem avaliações", verified: "Perfil verificado", verifiedBadge: "Verificado", memberSince: "Membro desde" },
     badge: { newThisWeek: "Novo esta semana", recentlyAdded: "Adicionado recentemente" },
     cta: { microcopy: "3 min · Grátis · Via Telegram" },
     login: {
@@ -426,7 +426,7 @@ translations.ru = {
     skills: "Навыки",
     contact: "Связаться",
   },
-  masterCard: { details: "OPEN", noReviews: "Пока нет отзывов", verified: "Профиль подтверждён", memberSince: "Участник с" },
+  masterCard: { details: "OPEN", noReviews: "Пока нет отзывов", verified: "Профиль подтверждён", verifiedBadge: "Проверено", memberSince: "Участник с" },
   badge: { newThisWeek: "Новый на этой неделе", recentlyAdded: "Недавно добавлен" },
   cta: { microcopy: "3 мин · Бесплатно · Через Telegram" },
   login: {
@@ -503,7 +503,7 @@ translations.de = {
     skills: "Fähigkeiten",
     contact: "Kontakt",
   },
-  masterCard: { details: "OPEN", noReviews: "Noch keine Bewertungen", verified: "Profil bestätigt", memberSince: "Dabei seit" },
+  masterCard: { details: "OPEN", noReviews: "Noch keine Bewertungen", verified: "Profil bestätigt", verifiedBadge: "Bestätigt", memberSince: "Dabei seit" },
   badge: { newThisWeek: "Neu diese Woche", recentlyAdded: "Kürzlich hinzugefügt" },
   cta: { microcopy: "3 Min · Kostenlos · Über Telegram" },
   login: {
@@ -580,7 +580,7 @@ translations.fr = {
     skills: "Compétences",
     contact: "Contact",
   },
-  masterCard: { details: "OPEN", noReviews: "Pas encore d'avis", verified: "Profil vérifié", memberSince: "Membre depuis" },
+  masterCard: { details: "OPEN", noReviews: "Pas encore d'avis", verified: "Profil vérifié", verifiedBadge: "Vérifié", memberSince: "Membre depuis" },
   badge: { newThisWeek: "Nouveau cette semaine", recentlyAdded: "Ajouté récemment" },
   cta: { microcopy: "3 min · Gratuit · Via Telegram" },
   login: {
@@ -657,7 +657,7 @@ translations.tr = {
     skills: "Beceriler",
     contact: "İletişim",
   },
-  masterCard: { details: "OPEN", noReviews: "Henüz değerlendirme yok", verified: "Profil doğrulandı", memberSince: "Üyelik tarihi" },
+  masterCard: { details: "OPEN", noReviews: "Henüz değerlendirme yok", verified: "Profil doğrulandı", verifiedBadge: "Doğrulandı", memberSince: "Üyelik tarihi" },
   badge: { newThisWeek: "Bu hafta yeni", recentlyAdded: "Yakın zamanda eklendi" },
   cta: { microcopy: "3 dk · Ücretsiz · Telegram üzerinden" },
   login: {
@@ -734,7 +734,7 @@ translations.es = {
     skills: "Habilidades",
     contact: "Contacto",
   },
-  masterCard: { details: "OPEN", noReviews: "Aún sin valoraciones", verified: "Perfil verificado", memberSince: "Miembro desde" },
+  masterCard: { details: "OPEN", noReviews: "Aún sin valoraciones", verified: "Perfil verificado", verifiedBadge: "Verificado", memberSince: "Miembro desde" },
   badge: { newThisWeek: "Nuevo esta semana", recentlyAdded: "Añadido recientemente" },
   cta: { microcopy: "3 min · Gratis · Vía Telegram" },
   login: {

--- a/web/spa/styles.css
+++ b/web/spa/styles.css
@@ -903,6 +903,7 @@ img {
 .master-card__badge--verified {
   background: var(--terra);
   color: var(--paper);
+  text-transform: uppercase;
 }
 .master-card__badge--new {
   background: var(--paper);


### PR DESCRIPTION
Promotes the verified-badge i18n work to production.

- New i18n key `masterCard.verifiedBadge` across all 9 locales; `MasterCard` and `Modal` use it instead of hardcoded English.
- `.master-card__badge--verified` now `text-transform: uppercase` so localized text (e.g. «ПЕРЕВІРЕНО») renders all-caps, matching the modal badge.
- Add `backend/scripts/backfill-og-images.js` to regenerate OG cards so only owner-verified masters keep the stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)