### PR TITLE
Fix: emit default og:image on all fallback pages

### DIFF
--- a/web/app/[lang]/[city]/[category]/page.tsx
+++ b/web/app/[lang]/[city]/[category]/page.tsx
@@ -11,7 +11,7 @@ import {
   cityPrep,
 } from "@/lib/data";
 import { buildSeed } from "@/lib/seed";
-import { abs } from "@/lib/urls";
+import { abs, DEFAULT_OG_IMAGE } from "@/lib/urls";
 import AppShell from "@/spa/AppShell";
 import Main from "@/spa/pages/Main";
 
@@ -79,7 +79,7 @@ export async function generateMetadata({
       canonical: abs(`/${lang}/${city.id}/${cat.id}`),
       languages: langAlt(city.id, cat.id),
     },
-    openGraph: { title, description, locale: OG_LOCALE[lang], type: "website" },
+    openGraph: { title, description, locale: OG_LOCALE[lang], type: "website", images: [DEFAULT_OG_IMAGE] },
   };
 }
 

--- a/web/app/[lang]/[city]/page.tsx
+++ b/web/app/[lang]/[city]/page.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/lib/data";
 import { buildSeed } from "@/lib/seed";
 import { cityHubDescription, professionHubDescription } from "@/lib/content";
-import { abs } from "@/lib/urls";
+import { abs, DEFAULT_OG_IMAGE } from "@/lib/urls";
 import AppShell from "@/spa/AppShell";
 import Main from "@/spa/pages/Main";
 
@@ -68,7 +68,7 @@ export async function generateMetadata({
       description,
       robots: isIndexable(lang) ? undefined : { index: false, follow: true },
       alternates: { canonical: abs(`/${lang}/${city.id}`), languages: langAlt(city.id) },
-      openGraph: { title, description, locale: OG_LOCALE[lang], type: "website" },
+      openGraph: { title, description, locale: OG_LOCALE[lang], type: "website", images: [DEFAULT_OG_IMAGE] },
     };
   }
   const { lang, cat } = r;
@@ -85,7 +85,7 @@ export async function generateMetadata({
     description,
     robots: isIndexable(lang) ? undefined : { index: false, follow: true },
     alternates: { canonical: abs(`/${lang}/${cat.id}`), languages: langAlt(cat.id) },
-    openGraph: { title, description, locale: OG_LOCALE[lang], type: "website" },
+    openGraph: { title, description, locale: OG_LOCALE[lang], type: "website", images: [DEFAULT_OG_IMAGE] },
   };
 }
 

--- a/web/app/[lang]/about/page.tsx
+++ b/web/app/[lang]/about/page.tsx
@@ -1,16 +1,10 @@
-import { notFound } from "next/navigation";
-import type { Metadata } from "next";
-import Link from "next/link";
-import Image from "next/image";
-import {
-  isLang,
-  isIndexable,
-  LANGS,
-  OG_LOCALE,
-  type Lang,
-} from "@/lib/i18n";
-import { abs, homePath, languageAlternates } from "@/lib/urls";
-import AppShell from "@/spa/AppShell";
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import { isLang, isIndexable, LANGS, OG_LOCALE, type Lang } from '@/lib/i18n';
+import { abs, homePath, languageAlternates, DEFAULT_OG_IMAGE } from '@/lib/urls';
+import AppShell from '@/spa/AppShell';
 
 export const revalidate = 86400;
 
@@ -21,20 +15,20 @@ export function generateStaticParams() {
 }
 
 function meta(lang: Lang) {
-  if (lang === "ru")
+  if (lang === 'ru')
     return {
-      title: "О нас — Majstr",
+      title: 'О нас — Majstr',
       description:
-        "Почему появился Majstr: личная история основателя и каталог украино- и русскоязычных специалистов в Италии, собранный из рекомендаций сообщества.",
+        'Почему появился Majstr: личная история основателя и каталог украино- и русскоязычных специалистов в Италии, собранный из рекомендаций сообщества.',
     };
-  if (lang === "en")
+  if (lang === 'en')
     return {
-      title: "About — Majstr",
+      title: 'About — Majstr',
       description:
         "Why Majstr exists: the founder's story and a curated directory of Ukrainian- and Russian-speaking specialists in Italy, built from community recommendations.",
     };
   return {
-    title: "Про нас — Majstr",
+    title: 'Про нас — Majstr',
     description:
       "Чому з'явився Majstr: особиста історія засновника й каталог україно- та російськомовних фахівців в Італії, зібраний із рекомендацій спільноти.",
   };
@@ -57,7 +51,14 @@ export async function generateMetadata({
       canonical: abs(aboutPath(lang)),
       languages: languageAlternates(aboutPath),
     },
-    openGraph: { title, description, url: abs(aboutPath(lang)), locale: OG_LOCALE[lang], type: "website" },
+    openGraph: {
+      title,
+      description,
+      url: abs(aboutPath(lang)),
+      locale: OG_LOCALE[lang],
+      type: 'website',
+      images: [DEFAULT_OG_IMAGE],
+    },
   };
 }
 
@@ -84,8 +85,8 @@ export default async function AboutPage({
           </h1>
 
           <p className="about-lead">
-            Мене звуть Константин, я живу в Італії з 2023 року. Я люблю цю країну, але
-            кілька разів потрапляв у неприємні ситуації.
+            Мене звуть Константин, я живу в Італії з 2023 року. Я люблю цю
+            країну, але кілька разів потрапляв у неприємні ситуації.
           </p>
 
           <div className="about-body">
@@ -106,23 +107,26 @@ export default async function AboutPage({
             </figure>
 
             <p>
-              Шукав квартиру у ріелторів, які не хотіли її здавати, переплачував за
-              ремонт автомобіля, а одного разу опинився в швидкій через те, що лікарка
-              мене не розуміла і призначала таблетки замість обстеження.
+              Шукав квартиру у ріелторів, які не хотіли її здавати, переплачував
+              за ремонт автомобіля, а одного разу опинився в швидкій через те,
+              що лікарка мене не розуміла і призначала пігулки замість
+              обстеження.
             </p>
             <p>
-              Вірю, що цього б не сталося, якби я знав контакти лікаря, ріелтора та інших
-              фахівців, <strong>з якими ми говоримо однією мовою</strong>.
+              Вірю, що цього б не сталося, якби я знав контакти лікаря, ріелтора
+              та інших фахівців,{' '}
+              <strong>з якими ми говоримо однією мовою</strong>.
             </p>
             <p>
-              Я зробив сервіс majstr: курований каталог україномовних та російськомовних
-              фахівців, заснований на рекомендаціях людей у телеграм-чатах та групах
-              соцмереж. Я починав це як каталог особистих рекомендацій, та згодом вирішив
-              зробити версію, відкриту для спільноти.
+              Я зробив сервіс majstr: курований каталог україномовних та
+              російськомовних фахівців, заснований на рекомендаціях людей у
+              телеграм-чатах та групах соцмереж. Я починав це як каталог
+              особистих рекомендацій, та згодом вирішив зробити версію, відкриту
+              для спільноти.
             </p>
             <p>
-              Вірю, що комусь це допоможе знайти потрібного спеціаліста, а спеціалістам —{" "}
-              <strong>своїх клієнтів</strong>.
+              Вірю, що комусь це допоможе знайти потрібного спеціаліста, а
+              спеціалістам — <strong>своїх клієнтів</strong>.
             </p>
           </div>
 

--- a/web/app/[lang]/faq/page.tsx
+++ b/web/app/[lang]/faq/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { isLang, isIndexable, LANGS, OG_LOCALE, type Lang } from "@/lib/i18n";
-import { abs, languageAlternates } from "@/lib/urls";
+import { abs, languageAlternates, DEFAULT_OG_IMAGE } from "@/lib/urls";
 import AppShell from "@/spa/AppShell";
 import Faq from "@/spa/components/Faq";
 
@@ -50,7 +50,7 @@ export async function generateMetadata({
       canonical: abs(faqPath(lang)),
       languages: languageAlternates(faqPath),
     },
-    openGraph: { title, description, url: abs(faqPath(lang)), locale: OG_LOCALE[lang], type: "website" },
+    openGraph: { title, description, url: abs(faqPath(lang)), locale: OG_LOCALE[lang], type: "website", images: [DEFAULT_OG_IMAGE] },
   };
 }
 

--- a/web/app/[lang]/page.tsx
+++ b/web/app/[lang]/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { LANGS, isLang, isIndexable, OG_LOCALE, type Lang } from "@/lib/i18n";
 import { getDataset } from "@/lib/data";
 import { buildSeed } from "@/lib/seed";
-import { abs, homePath, languageAlternates } from "@/lib/urls";
+import { abs, homePath, languageAlternates, DEFAULT_OG_IMAGE } from "@/lib/urls";
 import { SITE_URL } from "@/lib/config";
 import AppShell from "@/spa/AppShell";
 import Main from "@/spa/pages/Main";
@@ -54,7 +54,7 @@ export async function generateMetadata({
       canonical: abs(homePath(lang)),
       languages: languageAlternates((l) => homePath(l)),
     },
-    openGraph: { title, description, url: abs(homePath(lang)), locale: OG_LOCALE[lang], type: "website" },
+    openGraph: { title, description, url: abs(homePath(lang)), locale: OG_LOCALE[lang], type: "website", images: [DEFAULT_OG_IMAGE] },
   };
 }
 

--- a/web/app/[lang]/privacy/page.tsx
+++ b/web/app/[lang]/privacy/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { isLang, type Lang } from "@/lib/i18n";
-import { abs, homePath, languageAlternates } from "@/lib/urls";
+import { abs, homePath, languageAlternates, DEFAULT_OG_IMAGE } from "@/lib/urls";
 import { API_BASE } from "@/lib/config";
 
 interface PolicySection {
@@ -55,6 +55,7 @@ export async function generateMetadata({
       title,
       url: abs(privacyPath(lang)),
       type: "website",
+      images: [DEFAULT_OG_IMAGE],
     },
   };
 }

--- a/web/lib/urls.ts
+++ b/web/lib/urls.ts
@@ -9,6 +9,19 @@ export const landingPath = (lang: Lang, profSlug: string, citySlug: string) =>
   `/${lang}/${profSlug}/${citySlug}`;
 export const masterPath = (lang: Lang, slug: string) => `/${lang}/m/${slug}`;
 
+// Default social card for every page that doesn't render its own (home, about,
+// faq, privacy, city, category). Next's file-convention opengraph-image
+// (app/opengraph-image.png) only attaches to root-level routes — it does NOT
+// cascade into the [lang] tree — and a page's own openGraph object shallow-
+// overrides the layout's, so each fallback page must reference this explicitly.
+// Served by the file-convention route at /opengraph-image.png.
+export const DEFAULT_OG_IMAGE = {
+  url: abs("/opengraph-image.png"),
+  width: 1200,
+  height: 630,
+  alt: "Majstr — каталог майстрів в Італії",
+};
+
 // hreflang alternates for a page that exists in every indexed locale. `build`
 // maps a lang to its localized path. Iterates INDEXED_LANGS so a gated locale
 // (e.g. en while its content is unpublished) is not advertised to crawlers.


### PR DESCRIPTION
Follow-up to #126. The new default OG card deployed, but the `[lang]` pages (home, about, faq, privacy, city, category) were shipping with **no `og:image`** — Next's file-convention `opengraph-image` only attaches to root-level routes (it doesn't cascade into the `[lang]` tree), and each page's own `openGraph` object shallow-overrides the layout's.

Fix: shared `DEFAULT_OG_IMAGE` in `lib/urls.ts`, referenced explicitly in each fallback page's `openGraph`. Master pages keep their per-master S3 card. Next derives `twitter:image` from it automatically.

Verified in a local build: home/about/faq emit `og:image` + `twitter:image` → `https://majstr.xyz/opengraph-image.png` (1200×630, alt set); a master page still points to its S3 image.

Also folds in the previously-uncommitted about-page formatting + «таблетки»→«пігулки» wording tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)