### PR TITLE
fix: post-cutover bugs (app-surface beige stripe + own-phone share treated as lead)

### DIFF
--- a/backend/bot/forwardLeads.js
+++ b/backend/bot/forwardLeads.js
@@ -44,7 +44,12 @@ function isForwarded(message) {
     message.forward_from ||
     message.forward_from_chat ||
     message.forward_sender_name ||
-    message.contact // a shared/forwarded contact card is a lead too
+    // A shared/forwarded contact card (a third party's number) is a lead — but
+    // NOT the sender sharing their OWN phone (the onboarding "share contact"
+    // step, where contact.user_id === the sender). That self-share must be
+    // ignored, not queued as a mined lead.
+    (message.contact &&
+      !(message.from && message.contact.user_id === message.from.id))
   );
 }
 

--- a/backend/test/bot/forwardLeads.test.js
+++ b/backend/test/bot/forwardLeads.test.js
@@ -41,7 +41,19 @@ describe('isForwarded', () => {
     expect(isForwarded({ forward_origin: {} })).toBe(true);
     expect(isForwarded({ forward_sender_name: 'X' })).toBe(true);
     expect(isForwarded({ contact: { phone_number: '+39' } })).toBe(true);
+    // Third-party contact (user_id differs from sender) is still a lead.
+    expect(
+      isForwarded({ contact: { user_id: 9, phone_number: '+39' }, from: { id: 5 } })
+    ).toBe(true);
     expect(isForwarded({ text: '/start' })).toBe(false);
+  });
+
+  it('ignores the sender sharing their OWN phone (onboarding share-contact)', () => {
+    // requestContact() during onboarding delivers the user's own contact to the
+    // bot chat — contact.user_id === from.id — and must NOT be queued as a lead.
+    expect(
+      isForwarded({ contact: { user_id: 5, phone_number: '+39' }, from: { id: 5 } })
+    ).toBe(false);
   });
 });
 

--- a/web/app/(app)/layout.tsx
+++ b/web/app/(app)/layout.tsx
@@ -50,7 +50,12 @@ export default function AppGroupLayout({ children }: { children: ReactNode }) {
         <meta name="robots" content="noindex" />
         <script src="https://telegram.org/js/telegram-web-app.js" />
       </head>
-      <body>
+      {/* The global styles.css paints body with the catalogue's --cream and, on
+          mobile, adds padding-top for the site header — both wrong for the app
+          surfaces (a beige stripe above the wizard). The old wizard.css fix
+          keyed on the Vite `#root` node, which doesn't exist in Next. Set the
+          app/theme background + drop the header offset directly on this body. */}
+      <body style={{ background: "var(--app-bg)", paddingTop: 0 }}>
         <AppProviders>{children}</AppProviders>
       </body>
     </html>


### PR DESCRIPTION
Two bugs surfaced testing the Mini App after the Phase 1 cutover:

1. **Beige stripe atop the app surfaces** — `styles.css` paints `body` with the catalogue's `--cream` (+ a mobile header-offset padding); the old `wizard.css` neutralizer keyed on the Vite `#root` node, gone in Next. Fix: `background:var(--app-bg)` + `padding-top:0` on the `(app)` layout body.
2. **Sharing your own phone queued as a mined lead** — onboarding `requestContact()` delivers the user's own contact to the bot chat; `isForwarded()` flagged any `message.contact` as a lead ("Saved to the queue"). Fix: a contact is a lead unless it's the sender's own (`contact.user_id === from.id`). +test.

Verified: backend 172 tests pass; web tsc + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)