### PR TITLE
fix → prod: post-cutover bugs (beige stripe + own-phone share)

### DIFF
--- a/backend/bot/forwardLeads.js
+++ b/backend/bot/forwardLeads.js
@@ -44,7 +44,12 @@ function isForwarded(message) {
     message.forward_from ||
     message.forward_from_chat ||
     message.forward_sender_name ||
-    message.contact // a shared/forwarded contact card is a lead too
+    // A shared/forwarded contact card (a third party's number) is a lead — but
+    // NOT the sender sharing their OWN phone (the onboarding "share contact"
+    // step, where contact.user_id === the sender). That self-share must be
+    // ignored, not queued as a mined lead.
+    (message.contact &&
+      !(message.from && message.contact.user_id === message.from.id))
   );
 }
 

--- a/backend/test/bot/forwardLeads.test.js
+++ b/backend/test/bot/forwardLeads.test.js
@@ -41,7 +41,19 @@ describe('isForwarded', () => {
     expect(isForwarded({ forward_origin: {} })).toBe(true);
     expect(isForwarded({ forward_sender_name: 'X' })).toBe(true);
     expect(isForwarded({ contact: { phone_number: '+39' } })).toBe(true);
+    // Third-party contact (user_id differs from sender) is still a lead.
+    expect(
+      isForwarded({ contact: { user_id: 9, phone_number: '+39' }, from: { id: 5 } })
+    ).toBe(true);
     expect(isForwarded({ text: '/start' })).toBe(false);
+  });
+
+  it('ignores the sender sharing their OWN phone (onboarding share-contact)', () => {
+    // requestContact() during onboarding delivers the user's own contact to the
+    // bot chat — contact.user_id === from.id — and must NOT be queued as a lead.
+    expect(
+      isForwarded({ contact: { user_id: 5, phone_number: '+39' }, from: { id: 5 } })
+    ).toBe(false);
   });
 });
 

--- a/web/app/(app)/layout.tsx
+++ b/web/app/(app)/layout.tsx
@@ -50,7 +50,12 @@ export default function AppGroupLayout({ children }: { children: ReactNode }) {
         <meta name="robots" content="noindex" />
         <script src="https://telegram.org/js/telegram-web-app.js" />
       </head>
-      <body>
+      {/* The global styles.css paints body with the catalogue's --cream and, on
+          mobile, adds padding-top for the site header — both wrong for the app
+          surfaces (a beige stripe above the wizard). The old wizard.css fix
+          keyed on the Vite `#root` node, which doesn't exist in Next. Set the
+          app/theme background + drop the header offset directly on this body. */}
+      <body style={{ background: "var(--app-bg)", paddingTop: 0 }}>
         <AppProviders>{children}</AppProviders>
       </body>
     </html>


### PR DESCRIPTION
Promotes #130 to production: app-surface beige-stripe fix (web) + own-phone-share no longer queued as a mined lead (bot). Backend deploys via Railway from main/backend; web via majstr-frontend from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)