### PR TITLE
fix(web): onboarding name-clear, submit loading, success close button

### DIFF
--- a/web/spa/onboarding/OnboardingWizard.tsx
+++ b/web/spa/onboarding/OnboardingWizard.tsx
@@ -125,6 +125,20 @@ function WizardInner() {
           <div className="wizard-success-icon">✅</div>
           <h2 className="wizard-success-title">{t("success.title")}</h2>
           <p className="wizard-success-text">{t("success.text")}</p>
+          <div className="wizard-actions" style={{ width: "100%", maxWidth: 320 }}>
+            <button
+              type="button"
+              className="wizard-solid-btn"
+              onClick={() => {
+                // Inside Telegram, close the Mini App; on the web, go home.
+                const wa = window.Telegram?.WebApp;
+                if (wa?.close) wa.close();
+                else window.location.href = "/";
+              }}
+            >
+              {t("success.done")}
+            </button>
+          </div>
         </div>
       </div>
     );
@@ -147,6 +161,7 @@ function WizardInner() {
           label={isLast ? t("nav.submit") : t("nav.next")}
           onPress={handleNext}
           isEnabled={isStepValid && !isSyncing && !isSubmitting}
+          isLoading={isSubmitting}
         />
       </div>
     </FormProvider>

--- a/web/spa/onboarding/i18n.tsx
+++ b/web/spa/onboarding/i18n.tsx
@@ -57,6 +57,7 @@ const UK: Dict = {
   "success.title": "Дякуємо!",
   "success.text":
     "Вашу картку надіслано на модерацію. Ми повідомимо вас у Telegram, щойно її буде схвалено.",
+  "success.done": "Готово",
   "submit.failTitle": "Не вдалося надіслати",
   "submit.failOk": "Зрозуміло",
   "submit.errExists": "У вас вже є активна картка майстра.",
@@ -150,6 +151,7 @@ const EN: Dict = {
   "success.title": "Thank you!",
   "success.text":
     "Your card has been submitted for review. We'll notify you in Telegram as soon as it's approved.",
+  "success.done": "Done",
   "submit.failTitle": "Couldn't submit",
   "submit.failOk": "Got it",
   "submit.errExists": "You already have an active master card.",

--- a/web/spa/onboarding/steps/StepProfile.tsx
+++ b/web/spa/onboarding/steps/StepProfile.tsx
@@ -36,10 +36,15 @@ export function StepProfile() {
       .catch(() => setHasTgPhoto(false));
   }, []);
 
-  // Prefill name from Telegram initData if form is still empty.
+  // Prefill name from Telegram initData if the field is still empty. Guarded to
+  // run only ONCE: without this, emptying the field to retype (e.g. Konstantin →
+  // Константин) re-triggers the effect and restores the old value — the user
+  // can never clear it.
+  const namePrefilled = useRef(false);
   useEffect(() => {
-    const current = form.getValues("name");
-    if (!current && user) {
+    if (namePrefilled.current || !user) return;
+    namePrefilled.current = true;
+    if (!form.getValues("name")) {
       const suggested = [user.first_name, user.last_name?.[0]]
         .filter(Boolean)
         .join(" ");


### PR DESCRIPTION
1) name field couldn't be cleared (prefill re-fired on empty → guard to run once); 2) submit now shows loading (isLoading on PrimaryCTA); 3) success screen gets a Done button that closes the Mini App. tsc+build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)