### PR TITLE
fix(web): serve master photos straight from S3 (skip Vercel image optimizer)

### DIFF
--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -8,9 +8,12 @@ const nextConfig = {
   reactStrictMode: true,
   trailingSlash: false,
   images: {
-    // Master photos live in the chupakabra-test S3 bucket (region host +
-    // legacy global host). Serve them through the Next optimizer as AVIF/WebP.
-    formats: ["image/avif", "image/webp"],
+    // Master photos are already resized at upload (sharp → ≤1024px JPEG, ~40KB)
+    // and live in the chupakabra-test S3 bucket. Serve them straight from S3 and
+    // SKIP Vercel Image Optimization: the optimizer adds little for pre-sized
+    // images and its monthly transform quota was being exhausted, which made new
+    // master photos stop rendering on the cards. unoptimized = no quota, no blanks.
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: "https",


### PR DESCRIPTION
Vercel Image Optimization monthly quota was exhausted → optimizer errored → master cards blank. Master photos are already resized at upload (≤1024px JPEG, ~40KB, public on S3), so set images.unoptimized to serve them directly — no quota, correct for a growing pre-sized image catalogue. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)