### PR TITLE
fix(claims): supersede abandoned draft instead of blocking the claim

### DIFF
--- a/backend/routes/claims.js
+++ b/backend/routes/claims.js
@@ -71,14 +71,22 @@ async function submitClaim(req, res) {
   if (!master.claimable) return res.status(409).json({ error: 'not_claimable' });
 
   // One active card per owner (partial unique index on ownerUserID). Without
-  // this check the ownership transfer below throws E11000 — surface a clear
-  // 409 instead.
-  const hasActiveCard = await Master.exists({
+  // this the ownership transfer below throws E11000. A real (submitted) card —
+  // pending or approved — legitimately blocks the claim, so surface a clear
+  // 409. But an unsubmitted `draft` is an abandoned "add card" attempt (often
+  // an empty, unsubmittable shell); it must not permanently dead-end the user
+  // out of claiming their real (e.g. scraped) card. Supersede it: drop the
+  // draft, then proceed with the claim.
+  const activeCard = await Master.findOne({
     ownerUserID: req.user._id,
     status: { $in: Master.ACTIVE_STATUSES },
   });
-  if (hasActiveCard) {
-    return res.status(409).json({ error: 'active_card_exists' });
+  if (activeCard) {
+    if (activeCard.status === 'draft') {
+      await Master.deleteOne({ _id: activeCard._id });
+    } else {
+      return res.status(409).json({ error: 'active_card_exists' });
+    }
   }
 
   // Build evidence from what the claimant provided

--- a/backend/test/routes/claims.test.js
+++ b/backend/test/routes/claims.test.js
@@ -93,6 +93,27 @@ describe('POST /api/claims', () => {
     expect(untouched.claimable).toBe(true);
   });
 
+  it('supersedes an abandoned draft (does not block) and claims the card', async () => {
+    const { user, authHeader } = await makeUser({ telegramID: 70015, username: 'majstrolena' });
+    // An unfinished "add card" draft must not dead-end the user out of claiming
+    // their real card — claiming drops the draft and transfers ownership.
+    const draft = await Master.create({ name: 'Wip', status: 'draft', ownerUserID: user._id });
+    const master = await makeClaimable();
+
+    const res = await request(app)
+      .post('/api/claims')
+      .set('Authorization', authHeader)
+      .send({ masterID: master._id });
+    expect(res.status).toBe(201);
+    expect(res.body.autoApproved).toBe(true);
+
+    // Draft gone, claimed card now owned by the user.
+    expect(await Master.findById(draft._id)).toBeNull();
+    const claimed = await Master.findById(master._id);
+    expect(claimed.ownerUserID.equals(user._id)).toBe(true);
+    expect(claimed.claimable).toBe(false);
+  });
+
   it('409s when the caller already owns the card', async () => {
     const { user, authHeader } = await makeUser();
     const master = await makeClaimable({ ownerUserID: user._id });


### PR DESCRIPTION
## Problem
Claiming a card via the profile banner failed with **"Не вдалося, у вас вже є активна картка"** (`active_card_exists`).

Root cause: an unsubmitted `draft` card counts as an "active card" under the one-card-per-owner rule. A half-started add-card attempt (e.g. an empty, unsubmittable draft) permanently dead-ended the user out of claiming their real (scraped) card.

## Fix
In `submitClaim`, distinguish a real submitted card from an abandoned draft:
- `pending`/`approved` → still blocks with `active_card_exists` (legitimate "you already have a card").
- `draft` → **superseded**: the draft is deleted and the claim proceeds.

Added a regression test; full claims suite green (17/17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)